### PR TITLE
Add logger to CryptoOps

### DIFF
--- a/src/client/OauthClient.ts
+++ b/src/client/OauthClient.ts
@@ -112,7 +112,7 @@ export class OauthClient {
     }
 
     // Initialize the crypto class.
-    this.browserCrypto = new CryptoOps()
+    this.browserCrypto = new CryptoOps(this.logger)
 
     // Initialize the browser storage class.
     this.browserStorage = new BrowserCacheManager(


### PR DESCRIPTION
Fix an error where cypress is complaingin about a call to logger.verbose where logger is undefined.

This is an attempt to fix #5 