### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The login command requires three parameters. Here is a minimal example:
 ```
 cy.msalLogin(
   {
-    email: 'my-test-user@cypress.com',
+    username: 'my-test-user@cypress.com',
     password: 'whatever'
   },
   {


### PR DESCRIPTION
Fix example given in README.md

OauthCredentials type does not contain `email`
Updated `email` to `username`