### PR TITLE
fix: exposing full password to Cypress log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,24 @@ Cypress.Commands.add(
   'msalLogin',
   function (loginParams: OauthCredentials, configuration: Configuration, scopes: Array<string>) {
     Cypress.log({
-      name: 'msal SSO login ',
-    })
+      name: "msal SSO login",
+      message: JSON.stringify({
+        loginParams: {
+          username: loginParams.username, password: loginParams.password?.substring(0, 4),
+        },
+        configuration: configuration,
+        scopes: scopes,
+      }),
+      consoleProps: () => {
+        return {
+          loginParams: {
+            username: loginParams.username, password: loginParams.password?.substring(0, 4),
+          },
+          configuration: configuration,
+          scopes: scopes,
+        }
+      }
+    });
 
     const AzureTokenUrl = `${configuration.auth.authority}/oauth2/v2.0/token`
     const oauthClient = new OauthClient(configuration)


### PR DESCRIPTION
The Cypress.log command when no message parameter is passed to it will include all of the function parameters which in this case includes the password for your Azure login.  This PR changes the log command so that it only shows the 1st 4 letters of the password in the log and in the console.